### PR TITLE
Fix: changed absolute path to relative path

### DIFF
--- a/src/PropertyHelper.java
+++ b/src/PropertyHelper.java
@@ -13,7 +13,7 @@ public class PropertyHelper extends Properties{
 			try {
 				instance = new PropertyHelper();
 							
-				FileInputStream stream =new FileInputStream("C:\\th_workspace\\BitcoinReader\\src\\import.properties");
+				FileInputStream stream =new FileInputStream(".\\src\\import.properties");
 				
 				instance.load(stream);
 					

--- a/src/import.properties
+++ b/src/import.properties
@@ -6,7 +6,7 @@ browser = Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.8.1.12) Gecko/200802
 
 url = https://www.finanzen.net/devisen/bitcoin-euro-kurs
 
-output = C:\\th_workspace\\BitcoinReader\\src\\bitcoin.price
+output = .\\bitcoin.price
 
 tokenone = <div>
 


### PR DESCRIPTION
The program crashed if it was not started from a specific path. To fix this I changed all absolute paths to relative paths.